### PR TITLE
Add configuration XML Schema Definition for easy use in IDEs and editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ using the [Keep a CHANGELOG](https://keepachangelog.com/) principles.
 ### Added
 
 - OpenAI Translator now throws exception if no API key was set
+- `config.xsd` for autocompletion in IDEs and editors. Use either from the composer dependency `vendor/boxblinkracer/phpunuhi/config.xsd` or online `https://raw.githubusercontent.com/boxblinkracer/phpunuhi/main/config.xsd`
 
 ## [1.0.1]
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,10 @@ Let's create a new **phpunuhi.xml** file (or rename it to something else).
 
 ```xml
 
-<phpunuhi>
+<phpunuhi
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/boxblinkracer/phpunuhi/main/config.xsd"
+>
     <translations>
 
         <set name="Storefront">
@@ -126,7 +129,10 @@ Look at this one:
 
 ```xml
 
-<phpunuhi>
+<phpunuhi
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/boxblinkracer/phpunuhi/main/config.xsd"
+>
     <translations>
 
         <set name="Storefront">

--- a/config.xsd
+++ b/config.xsd
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified"
+>
+    <xs:element name="phpunuhi">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element
+                    name="translations"
+                    type="translation"
+                    maxOccurs="unbounded"
+                    minOccurs="1"
+                />
+            </xs:sequence>
+        </xs:complexType>
+
+        <!-- Set names shall be unique -->
+        <xs:unique name="uniqueSetName">
+            <xs:selector xpath="translations/set"/>
+            <xs:field xpath="@name"/>
+        </xs:unique>
+    </xs:element>
+
+    <xs:complexType name="translation">
+        <xs:choice
+            minOccurs="1"
+            maxOccurs="unbounded"
+        >
+            <xs:element
+                name="set"
+                type="set"
+                minOccurs="1"
+                maxOccurs="unbounded"
+            />
+        </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="set">
+        <xs:choice
+            minOccurs="1"
+            maxOccurs="unbounded"
+        >
+            <xs:element
+                name="file"
+                type="file"
+                maxOccurs="unbounded"
+                minOccurs="1"
+            />
+        </xs:choice>
+
+        <xs:attribute
+            name="name"
+            type="xs:string"
+            use="required"
+        />
+        <xs:attribute
+            name="format"
+            type="formatCode"
+            default="json"
+            use="optional"
+        />
+        <xs:attribute
+            name="sort"
+            type="xs:boolean"
+            default="false"
+            use="optional"
+        />
+
+        <!-- format="json" specific -->
+        <xs:attribute
+            name="jsonIndent"
+            type="xs:positiveInteger"
+            default="2"
+            use="optional"
+        />
+    </xs:complexType>
+    <xs:complexType name="file">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute
+                    name="locale"
+                    type="localeCode"
+                    use="required"
+                />
+
+                <!-- format="ini" specific -->
+                <xs:attribute
+                    name="iniSection"
+                    type="xs:string"
+                    use="optional"
+                />
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <!-- literals -->
+    <xs:simpleType name="formatCode">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="json"/>
+            <xs:enumeration value="ini"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="localeCode">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[a-z]{2}(-[A-Z]{2})?"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="nonEmptyString">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[a-zA-Z][a-zA-Z0-9]*"/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>


### PR DESCRIPTION
As mentioned: I wanted to do it with XSD1.1 but it's editor support is basically non existent for the features, that would support here. So we just stay on XSD1.0 :) works out very good.