### PR TITLE
Moved file existence check to a point, where configuration is available for a good error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ using the [Keep a CHANGELOG](https://keepachangelog.com/) principles.
 
 - OpenAI Translator now throws exception if no API key was set
 
+### Fixed
+
+- Include referenced translation file from configuration in error message when translation file is not found
+
 ## [1.0.1]
 
 ### Fixed

--- a/src/Bundles/Storage/INI/IniStorage.php
+++ b/src/Bundles/Storage/INI/IniStorage.php
@@ -31,12 +31,8 @@ class IniStorage implements StorageInterface
      */
     public function loadTranslations(Locale $locale): void
     {
-        if (!file_exists($locale->getFilename())) {
-            throw new \Exception('Attention, translation file not found: ' . $locale->getFilename());
-        }
-
         $iniArray = parse_ini_file($locale->getFilename(), true, INI_SCANNER_RAW);
-        
+
         if ($iniArray === false) {
             throw new \Exception('Error when loading INI file: ' . $locale->getFilename());
         }

--- a/src/Bundles/Storage/JSON/JsonLoader.php
+++ b/src/Bundles/Storage/JSON/JsonLoader.php
@@ -16,10 +16,6 @@ class JsonLoader
      */
     function loadTranslations(Locale $locale): void
     {
-        if (!file_exists($locale->getFilename())) {
-            throw new \Exception('Attention, translation file not found: ' . $locale->getFilename());
-        }
-
         $snippetJson = (string)file_get_contents($locale->getFilename());
 
         $foundTranslations = [];

--- a/src/Components/Configuration/ConfigurationLoader.php
+++ b/src/Components/Configuration/ConfigurationLoader.php
@@ -71,7 +71,13 @@ class ConfigurationLoader
                 switch ($nodeType) {
                     case 'file':
 
-                        $fileName = (string)realpath(dirname($configFilename) . '/' . $nodeValue);
+                        $configuredFileName = dirname($configFilename) . '/' . $nodeValue;
+                        $fileName = realpath($configuredFileName);
+
+                        if ($fileName === false || !file_exists($fileName)) {
+                            throw new \Exception('Attention, translation file not found: ' . $configuredFileName);
+                        }
+
                         $localeAttr = (string)$childNode['locale'];
                         $iniSection = (string)$childNode['iniSection'];
 


### PR DESCRIPTION
I tested this in a pull request situation where a referenced file is removed. The error message is not helpful though:

> **Error**
> In JsonLoader.php line 20:
>                                           
>   Attention, translation file not found:  
>                                           
