### PR TITLE
Fix indent for json and yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ For this, you might want to use the **iniSection** feature and just assign the s
 
 <set name="sample">
 <format>
-    <ini indent="4" sort="true"/>
+    <ini sort="true"/>
 </format>
 <locales>
     <locale name="de" iniSection="de-DE">./snippets/snippets.ini</locale>

--- a/src/Bundles/Storage/JSON/JsonStorage.php
+++ b/src/Bundles/Storage/JSON/JsonStorage.php
@@ -65,7 +65,7 @@ class JsonStorage implements StorageInterface
      */
     public function configureStorage(TranslationSet $set): void
     {
-        $indent = $set->getAttributeValue('jsonIndent');
+        $indent = $set->getAttributeValue('indent');
         $indent = ($indent === '') ? '2' : $indent;
         $sort = filter_var($set->getAttributeValue('sort'), FILTER_VALIDATE_BOOLEAN);
         $eolLast = filter_var($set->getAttributeValue('eol-last'), FILTER_VALIDATE_BOOLEAN);

--- a/src/Bundles/Storage/YAML/YamlStorage.php
+++ b/src/Bundles/Storage/YAML/YamlStorage.php
@@ -67,7 +67,7 @@ class YamlStorage implements StorageInterface
      */
     public function configureStorage(TranslationSet $set): void
     {
-        $indent = $set->getAttributeValue('yamlIndent');
+        $indent = $set->getAttributeValue('indent');
         $indent = ($indent === '') ? '2' : $indent;
         $sort = filter_var($set->getAttributeValue('sort'), FILTER_VALIDATE_BOOLEAN);
         $eolLast = filter_var($set->getAttributeValue('eol-last'), FILTER_VALIDATE_BOOLEAN);


### PR DESCRIPTION
Yaml and Json Indent did not work properly as the wrong attribute name was used to load the indent. 

Also INI example had an indent flag even though that does not exist there