### PR TITLE
DeepL translator valid traget locale

### DIFF
--- a/src/Bundles/Translator/DeepL/DeeplTranslator.php
+++ b/src/Bundles/Translator/DeepL/DeeplTranslator.php
@@ -4,6 +4,7 @@ namespace PHPUnuhi\Bundles\Translator\DeepL;
 
 use DeepL\Translator;
 use Exception;
+use PHPUnuhi\Bundles\Translator\DeepL\Services\SupportedLanguages;
 use PHPUnuhi\Bundles\Translator\TranslatorInterface;
 use PHPUnuhi\Models\Command\CommandOption;
 use PHPUnuhi\Services\Placeholder\Placeholder;
@@ -114,13 +115,9 @@ class DeeplTranslator implements TranslatorInterface
 
         $translator = new Translator($this->apiKey);
 
-        if ($targetLocale === 'en') {
-            $targetLocale = 'en-GB';
-        }
-        if ($targetLocale === 'de-DE') {
-            $targetLocale = 'de';
-        }
+        $supportedLanguages = new SupportedLanguages($translator);
 
+        $targetLocale = $supportedLanguages->getAvailableLocale($targetLocale);
 
         $options = [
 

--- a/src/Bundles/Translator/DeepL/Services/SupportedLanguages.php
+++ b/src/Bundles/Translator/DeepL/Services/SupportedLanguages.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace PHPUnuhi\Bundles\Translator\DeepL\Services;
+
+use DeepL;
+use DeepL\DeepLException;
+use DeepL\Translator;
+
+class SupportedLanguages
+{
+    /**
+     * @var DeepL\Translator
+     */
+    private $translator;
+
+    /**
+     * @var array<DeepL\Language>
+     */
+    private static $supportedLanguages;
+
+    private const must_have_country = [
+        'en' => 'en-gb',
+        'pt' => 'pt-pt'
+    ];
+
+    /**
+     * @param DeepL\Translator $translator
+     */
+    public function __construct(Translator $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    /**
+     * @param string $locale
+     * @return string
+     */
+    public function getAvailableLocale($locale): string
+    {
+        $locale = strtolower($locale);
+
+        if (isset(self::must_have_country[$locale])) {
+            return self::must_have_country[$locale];
+        }
+
+        $supportedLocales = $this->getAvailableLanguages();
+
+        if (preg_match("/^([a-z]{2,})-[a-z]{2,}$/", $locale, $matches)) {
+            $localeCountry = $locale;
+            $locale = $matches[1];
+        }
+
+        if (isset($localeCountry) && isset($supportedLocales[$localeCountry])) {
+            return $localeCountry;
+        }
+
+        if (isset($supportedLocales[$locale])) {
+            return $locale;
+        }
+
+        throw new DeepLException(
+            'Supported languages are: ' . implode(', ', $supportedLocales) .
+            ' Not `'. $locale .'`'
+        );
+    }
+
+    /**
+     * @return array<DeepL\Language>
+     */
+    private function getAvailableLanguages(): array
+    {
+        if (self::$supportedLanguages !== null) {
+            return self::$supportedLanguages;
+        }
+
+        self::$supportedLanguages = [];
+
+        /** @var DeepL\Language $language */
+        foreach ($this->translator->getTargetLanguages() as $language) {
+            $locale = strtolower($language->code);
+            self::$supportedLanguages[$locale] = $language;
+        }
+
+        return self::$supportedLanguages;
+    }
+}

--- a/tests/phpunit/Bundles/Translator/DeepL/Services/SupportedLanguagesTest.php
+++ b/tests/phpunit/Bundles/Translator/DeepL/Services/SupportedLanguagesTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace phpunit\Bundles\Translator\DeepL\Services;
+
+use DeepL\DeepLException;
+use DeepL\Language;
+use DeepL\Translator;
+use PHPUnit\Framework\TestCase;
+use PHPUnuhi\Bundles\Translator\DeepL\Services\SupportedLanguages;
+use ReflectionClass;
+use stdClass;
+
+class SupportedLanguagesTest extends TestCase
+{
+    /**
+     * @dataProvider supportedLanguages
+     * @param stdClass $data
+     * @return void
+     */
+    public function testSupportedLocale(stdClass $data): void
+    {
+        //Arrange
+        $translator = $this->createMock(Translator::class);
+        $translator
+            ->method('getTargetLanguages')
+            ->willReturn([
+                new Language('GERMAN', 'DE', true),
+                new Language('FRANCE', 'FR', true),
+                new Language('ENGLISH', 'EN-GB', true),
+                new Language('ENGLISH', 'EN-US', true),
+            ]);
+
+        $service = new SupportedLanguages($translator);
+
+        //Act
+        $actual = $service->getAvailableLocale($data->locale);
+
+        //Assert
+        $this->assertEquals($data->expect, $actual);
+    }
+
+    /**
+     * @return array<array<stdClass>>
+     */
+    public function supportedLanguages(): array
+    {
+        return [
+            [(object)['locale' => 'de',    'expect' => 'de']],
+            [(object)['locale' => 'de-AT', 'expect' => 'de']],
+            [(object)['locale' => 'de-DE', 'expect' => 'de']],
+            [(object)['locale' => 'DE-CH', 'expect' => 'de']],
+            [(object)['locale' => 'fr-BE', 'expect' => 'fr']],
+            [(object)['locale' => 'fr-CH', 'expect' => 'fr']],
+            [(object)['locale' => 'fr',    'expect' => 'fr']],
+            [(object)['locale' => 'en',    'expect' => 'en-gb']],
+            [(object)['locale' => 'en-GB', 'expect' => 'en-gb']],
+            [(object)['locale' => 'en-US', 'expect' => 'en-us']],
+            [(object)['locale' => 'pt',    'expect' => 'pt-pt']],
+        ];
+    }
+
+    public function testNotSupportedLocale(): void
+    {
+        //Arrange
+        $translator = $this->createMock(Translator::class);
+        $translator
+            ->method('getTargetLanguages')
+            ->willReturn([
+                new Language('GERMAN', 'DE', true),
+            ]);
+
+        $service = new SupportedLanguages($translator);
+
+        //Asser
+        $this->expectException(DeepLException::class);
+
+        //Act
+        $service->getAvailableLocale('fr');
+    }
+
+    public function testCacheOneCallDeepLForLanguages(): void
+    {
+        //Arrange
+        $translator = $this->createMock(Translator::class);
+        $translator
+            ->expects($this->once()) //Assert
+            ->method('getTargetLanguages')
+            ->willReturn([
+                new Language('GERMAN', 'DE', true),
+            ]);
+
+        $service = new SupportedLanguages($translator);
+
+        //Act
+        $service->getAvailableLocale('de');
+        $service->getAvailableLocale('de');
+    }
+
+    protected function tearDown(): void
+    {
+        $refClass = new ReflectionClass(SupportedLanguages::class);
+
+        $refProperty = $refClass->getProperty('supportedLanguages');
+        $refProperty->setAccessible(true);
+        $refProperty->setValue(null);
+        $refProperty->setAccessible(false);
+    }
+}


### PR DESCRIPTION
The DeepL Translator checks the availability of the target language.
It doesn't matter whether the country code is included or not.

Fixed command

`phpunuhi translate --service=deepl  --source=de-DE --force=fr-FR`
or 
`phpunuhi translate --service=deepl  --source=de-DE --force=fr-BE`
or
`phpunuhi translate --service=deepl  --source=de-DE --force=fr-CH`