### PR TITLE
Change binary detection to also support umlauts and other special cha…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes of releases are documented in this file
 using the [Keep a CHANGELOG](https://keepachangelog.com/) principles.
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed binary detection to also support umlauts
+
+
 ## [1.20.0]
 
 ### Added

--- a/src/Traits/BinaryTrait.php
+++ b/src/Traits/BinaryTrait.php
@@ -37,6 +37,6 @@ trait BinaryTrait
      */
     protected function isBinary(string $str): bool
     {
-        return preg_match('~[^\x20-\x7E\t\r\n]~', $str) > 0;
+        return ! mb_check_encoding($str, 'UTF-8');
     }
 }

--- a/tests/phpunit/Traits/BinaryTraitTest.php
+++ b/tests/phpunit/Traits/BinaryTraitTest.php
@@ -54,6 +54,9 @@ class BinaryTraitTest extends TestCase
         $this->assertTrue($isBinary);
     }
 
+    /**
+     * @return array<int, array<int, string>>
+     */
     public function nonBinaryStrings(): array
     {
         return [
@@ -70,11 +73,10 @@ class BinaryTraitTest extends TestCase
      *
      * @return void
      */
-    public function testIsBinaryFalse($string): void
+    public function testIsBinaryFalse(string $string): void
     {
         $isBinary = $this->isBinary($string);
 
         $this->assertFalse($isBinary);
     }
 }
-

--- a/tests/phpunit/Traits/BinaryTraitTest.php
+++ b/tests/phpunit/Traits/BinaryTraitTest.php
@@ -54,13 +54,27 @@ class BinaryTraitTest extends TestCase
         $this->assertTrue($isBinary);
     }
 
+    public function nonBinaryStrings(): array
+    {
+        return [
+            [''],
+            ['Some Content'],
+            ['Content with umlauts: äöüß'],
+            ['Sóme Cotént'],
+            ['这是一些内容']
+        ];
+    }
+
     /**
+     * @dataProvider nonBinaryStrings
+     *
      * @return void
      */
-    public function testIsBinaryFalse(): void
+    public function testIsBinaryFalse($string): void
     {
-        $isBinary = $this->isBinary('');
+        $isBinary = $this->isBinary($string);
 
         $this->assertFalse($isBinary);
     }
 }
+


### PR DESCRIPTION
The previous implementation flags non-ASCII characters as binary, such as umlauts.
The new solution takes a different approach to recognizing whether it is a binary string.

Source: https://stackoverflow.com/a/76816100