### PR TITLE
Translate only SW6 entity content with value in main language

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -292,6 +292,7 @@
         <xs:simpleContent>
             <xs:extension base="xs:string">
                 <xs:attribute name="entity" type="xs:string" use="required"/>
+                <xs:attribute name="mainLocale" type="xs:string" use="optional"/>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>

--- a/src/Bundles/Storage/Shopware6/Models/EntityDbTranslations.php
+++ b/src/Bundles/Storage/Shopware6/Models/EntityDbTranslations.php
@@ -37,6 +37,6 @@ class EntityDbTranslations
             }, $this->dbTranslations[$languageId]);
         }
 
-        return $this->dbTranslations;
+        return $this->dbTranslations[$languageId];
     }
 }

--- a/src/Bundles/Storage/Shopware6/Models/EntityDbTranslations.php
+++ b/src/Bundles/Storage/Shopware6/Models/EntityDbTranslations.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace PHPUnuhi\Bundles\Storage\Shopware6\Models;
+
+use PHPUnuhi\Traits\BinaryTrait;
+
+class EntityDbTranslations
+{
+    use BinaryTrait;
+
+    private const LANGUAGE_ID_KEY = 'language_id';
+
+    private array $dbTranslations = [];
+    private ?array $columnsWithTranslationsInDefaultLanguage = null;
+    private string $entityIdKey;
+
+    public function __construct(string $entity, array $dbTranslations, ?string $defaultLanguageId)
+    {
+        $this->entityIdKey = $entity . '_id';
+        foreach ($dbTranslations as $dbTranslation) {
+            $dbTranslation[$this->entityIdKey] = $this->binaryToString($dbTranslation[$this->entityIdKey]);
+            $dbTranslation[self::LANGUAGE_ID_KEY] = $this->binaryToString($dbTranslation[self::LANGUAGE_ID_KEY]);
+
+            $this->dbTranslations[$dbTranslation[self::LANGUAGE_ID_KEY]][] = $dbTranslation;
+
+            if ($dbTranslation[self::LANGUAGE_ID_KEY] === $defaultLanguageId) {
+                $this->columnsWithTranslationsInDefaultLanguage[$dbTranslation[$this->entityIdKey]] = array_flip(array_keys(array_filter($dbTranslation)));
+            }
+        }
+    }
+
+    public function getLanguageTranslations(string $languageId): array
+    {
+        if ($this->columnsWithTranslationsInDefaultLanguage) {
+            return array_map(function ($a) {
+                return array_intersect_key($a, $this->columnsWithTranslationsInDefaultLanguage[$a[$this->entityIdKey]]);
+            }, $this->dbTranslations[$languageId]);
+        }
+
+        return $this->dbTranslations;
+    }
+}

--- a/src/Bundles/Storage/Shopware6/Service/TranslationLoader.php
+++ b/src/Bundles/Storage/Shopware6/Service/TranslationLoader.php
@@ -4,6 +4,7 @@ namespace PHPUnuhi\Bundles\Storage\Shopware6\Service;
 
 use Exception;
 use PDO;
+use PHPUnuhi\Bundles\Storage\Shopware6\Models\EntityDbTranslations;
 use PHPUnuhi\Bundles\Storage\Shopware6\Models\Sw6Locale;
 use PHPUnuhi\Bundles\Storage\Shopware6\Repository\EntityTranslationRepository;
 use PHPUnuhi\Bundles\Storage\Shopware6\Repository\LanguageRepository;
@@ -115,26 +116,29 @@ class TranslationLoader
         $entityIdKey = $entity . '_id';
 
         $allDbLanguages = $this->repoLanguages->getLanguages();
-        $allDbTranslations = $this->repoEntityTranslations->getTranslations($entity);
+
+        $mainLocale = $set->getAttributeValue('mainLocale');
+        if ($mainLocale !== '') {
+            $defaultLanguageID = $this->getShopwareLanguageId($mainLocale, $allDbLanguages);
+        }
+
+        $entityDbTranslations = new EntityDbTranslations(
+            $entity,
+            $this->repoEntityTranslations->getTranslations($entity),
+            $defaultLanguageID ?? null
+        );
 
         foreach ($set->getLocales() as $locale) {
-            $currentLanguageID = $this->getShopwareLanguageId($locale, $allDbLanguages);
+            $currentLanguageID = $this->getShopwareLanguageId($locale->getName(), $allDbLanguages);
 
             if ($currentLanguageID === '' || $currentLanguageID === '0') {
                 throw new Exception('no language found for locale: ' . $locale->getName());
             }
 
-            foreach ($allDbTranslations as $dbRow) {
+            foreach ($entityDbTranslations->getLanguageTranslations($currentLanguageID) as $dbRow) {
 
-                # read our primary entity id and the
-                # language id of the current translation row
-                $entityId = $this->binaryToString((string)$dbRow[$entityIdKey]);
-                $languageId = $this->binaryToString((string)$dbRow['language_id']);
-
-                # if it's not the language we are looking for, just skip
-                if ($languageId !== $currentLanguageID) {
-                    continue;
-                }
+                # read our primary entity id of the current translation row
+                $entityId = $dbRow[$entityIdKey];
 
                 # we need to create a group-identifier for our row. this is the current entity object
                 # for the product entity, a group will be a single product (T-Shirt A)
@@ -175,10 +179,10 @@ class TranslationLoader
      * @param Sw6Locale[] $allLanguages
      * @return string
      */
-    private function getShopwareLanguageId(Locale $locale, array $allLanguages): string
+    private function getShopwareLanguageId(string $locale, array $allLanguages): string
     {
         foreach ($allLanguages as $langEntity) {
-            if ($langEntity->getLocaleName() === $locale->getName()) {
+            if ($langEntity->getLocaleName() === $locale) {
                 return $langEntity->getLanguageId();
             }
         }
@@ -186,3 +190,4 @@ class TranslationLoader
         return '';
     }
 }
+


### PR DESCRIPTION
As noted in https://github.com/boxblinkracer/phpunuhi/issues/47, it is currently not possible to only consider content for entities that have a value in the standard language.

For example, if an article does not have a meta description in the main language, this should neither be considered as missing during validation nor during translation.

This PR contains a first rough approach on how to solve this in the context of Shopware6-Storage without adapting the basic logic of the framework.

Is there any interest in extending the existing storage accordingly, or would it be better to create a separate storage service for this purpose?