### PR TITLE
Handle nested array list structures.

### DIFF
--- a/src/Traits/ArrayTrait.php
+++ b/src/Traits/ArrayTrait.php
@@ -103,7 +103,7 @@ trait ArrayTrait
             }
 
             // merge result
-            $result = array_merge_recursive($result, $lastVal);
+            $result = array_replace_recursive($result, $lastVal);
         }
 
         return $result;

--- a/tests/phpunit/Traits/ArrayTraitTest.php
+++ b/tests/phpunit/Traits/ArrayTraitTest.php
@@ -194,4 +194,26 @@ class ArrayTraitTest extends TestCase
 
         $this->assertEquals($expected, $flat);
     }
+
+    public function testNestedArrayWithListOfArray(): void
+    {
+        $array = [
+            'blocks.0.title' => 'I am a title',
+            'blocks.0.content' => 'I am some content',
+        ];
+
+        $expected = [
+            'blocks' => [
+                [
+                    'title' => 'I am a title',
+                    'content' => 'I am some content',
+                ]
+            ],
+        ];
+
+        $actual = $this->getMultiDimensionalArray($array, '.');
+
+        $this->assertEquals($expected, $actual);
+        ;
+    }
 }


### PR DESCRIPTION
Previously, nested structures like `list.0.my_key` and `list.0.another_key` were transformed to:
```
[
  "list" => [
    ['my_key' => '...'],
    ['another_key' => '...']
  ]
]
```
After this change, they are transformed to:
```
[
  "list" => [
    [
      'my_key' => '...'
      'another_key' => '...'
    ]
  ]
]
```